### PR TITLE
fix errors in linux building

### DIFF
--- a/premake.lua
+++ b/premake.lua
@@ -107,7 +107,7 @@ project "fbx-conv"
 	--- LINUX ----------------------------------------------------------
 	configuration { "linux" }
 		kind "ConsoleApp"
-		buildoptions { "-Wall" }
+		buildoptions { "-Wall -std=c++11" }
 		-- TODO: while using x64 will likely be fine for most people nowadays,
 		--       we still need to make this configurable
 		libdirs {

--- a/src/modeldata/FileIO.cpp
+++ b/src/modeldata/FileIO.cpp
@@ -1,5 +1,6 @@
 #include "FileIO.h"
 #include <cassert>
+#include <cstring>
 namespace fbxconv
 {
 

--- a/src/modeldata/Node.h
+++ b/src/modeldata/Node.h
@@ -25,6 +25,7 @@
 #include "NodePart.h"
 #include "../json/BaseJSONWriter.h"
 #include <list>
+#include <algorithm>
 namespace fbxconv {
 namespace modeldata {
 	/** A node is responsable for destroying its parts and children */


### PR DESCRIPTION
There're errors when I've tried to build cocos2d/fbx-conv in ubuntu 14.04. The original fbx-conv don't have such errors.
